### PR TITLE
把一些中文标点改成英文标点

### DIFF
--- a/eBook/04.7.md
+++ b/eBook/04.7.md
@@ -15,21 +15,21 @@ Example 4.13 [presuffix.go](examples/chapter_4/presuffix.go)
 	package main
 
 	import (
-		“fmt”
-		“strings”
+		"fmt"
+		"strings"
 	)
 
 	func main() {
-		var str string = “This is an example of a string”
-		fmt.Printf(“T/F? Does the string \”%s\” have prefix %s? “, str, “Th”)
-		fmt.Printf(“%t\n”, strings.HasPrefix(str, “Th”))
+		var str string = "This is an example of a string"
+		fmt.Printf("T/F? Does the string \"%s\" have prefix %s? ", str, "Th")
+		fmt.Printf("%t\n", strings.HasPrefix(str, "Th"))
 	}
 
 输出：
 
-	T/F? Does the string “This is an example of a string” have prefix Th? True
+	T/F? Does the string "This is an example of a string" have prefix Th? true
 
-这个例子同样演示了转移字符 `\` 和格式化字符串的使用。
+这个例子同样演示了转义字符 `\` 和格式化字符串的使用。
 
 ##4.7.2 字符串包含关系
 `Contains` 判断字符串 `s` 是否包含 `substr`：
@@ -75,10 +75,10 @@ Example 4.14 [index_in_string.go](examples/chapter_4/index_in_string.go)
 
 输出：
 
-	The position of “Marc” is: 8
-	The position of the first instance of “Hi” is: 0
-	The position of the last instance of “Hi” is: 14
-	The position of “Burger” is: -1
+	The position of "Marc" is: 8
+	The position of the first instance of "Hi" is: 0
+	The position of the last instance of "Hi" is: 14
+	The position of "Burger" is: -1
 
 ##4.7.4 字符串替换
 `Replace` 用于将字符串 `str` 中的前 `n` 个字符串 `old` 替换为字符串 `new`，并返回一个新的字符串，如果 `n = -1` 则替换所有字符串 `old` 为字符串 `new`：
@@ -112,7 +112,7 @@ Example 4.15 [count_substring.go](examples/chapter_4/count_substring.go)
 
 输出：
 
-	Number of H’s in Hello, how is it going, Hugo? is: 2
+	Number of H's in Hello, how is it going, Hugo? is: 2
 	Number of double g’s in gggggggggg is: 5
 
 ##4.7.6 重复字符串
@@ -178,7 +178,7 @@ Example 4.17 [toupper_lower.go](examples/chapter_4/toupper_lower.go)
 	The uppercase string is: HEY, HOW ARE YOU GEORGE?
 
 ##4.7.8 修剪字符串
-你可以使用 `strings.TrimSpace(s)` 来剔除字符串开头和结尾的空白符号；如果你想要剔除指定字符，则可以使用 `strings.Trim(s, “cut”)` 来将开头和结尾的 `cut` 去除掉。该函数的第二个参数可以包含任何字符，如果你只想剔除开头或者结尾的字符串，则可以使用 `TrimLeft` 或者 `TrimRight` 来实现。
+你可以使用 `strings.TrimSpace(s)` 来剔除字符串开头和结尾的空白符号；如果你想要剔除指定字符，则可以使用 `strings.Trim(s, "cut")` 来将开头和结尾的 `cut` 去除掉。该函数的第二个参数可以包含任何字符，如果你只想剔除开头或者结尾的字符串，则可以使用 `TrimLeft` 或者 `TrimRight` 来实现。
 
 ##4.7.9 分割字符串
 `strings.Fields(s)` 将会利用 1 个或多个空白符号来作为动态长度的分隔符将字符串分割成若干小块，并返回一个 slice，如果字符串只包含空白符号，则返回一个长度为 0 的 slice。
@@ -241,14 +241,14 @@ Example 4.18 [strings_splitjoin.go](examples/chapter_4/strings_splitjoin.go)
 
 该包包含了一些变量用于获取程序运行的操作系统平台下 int 类型所占的位数，如：`strconv.IntSize`。
 
-任何类型 T 转换为字符串总是成功的。
+任何类型 **T** 转换为字符串总是成功的。
 
 针对从数字类型转换到字符串，Go 提供了以下函数：
 
 - `strconv.Itoa(i int) string` 返回数字 i 所表示的字符串类型的十进制数。
-- `strconv.FormatFloat(f float64, fmt byte, prec int, bitSize int) string` 将 64 位浮点型的数字转换为字符串，其中 `fmt` 表示格式（其值可以是 `‘b’`、`‘e’`、`‘f’` 或 `‘g’`），`prec` 表示精度，`bitSize` 则使用 32 表示 float32，用 64 表示 float64。
+- `strconv.FormatFloat(f float64, fmt byte, prec int, bitSize int) string` 将 64 位浮点型的数字转换为字符串，其中 `fmt` 表示格式（其值可以是 `'b'`、`'e'`、`'f'` 或 `'g'`），`prec` 表示精度，`bitSize` 则使用 32 表示 float32，用 64 表示 float64。
 
-将字符串转换为其它类型 tp 并不总是可能的，可能会在运行时抛出错误 `parsing “…”: invalid argument`。
+将字符串转换为其它类型 **tp** 并不总是可能的，可能会在运行时抛出错误 `parsing "…": invalid argument`。
 
 针对从字符串类型转换为数字类型，Go 提供了以下函数：
 


### PR DESCRIPTION
1. 把一些中文 “ 和 ‘ 改成英文 " 和 '
2. 修正 Example 4.13 的输出结果
3. 加粗显示 **T** 和 **tp**
