### PR TITLE
Update 04.4.md

### DIFF
--- a/eBook/04.4.md
+++ b/eBook/04.4.md
@@ -97,7 +97,7 @@ Example 4.5 [goos.go](examples/chapter_4/goos.go)
 	)
 
 	func main() {
-		var goos string = os.Getenv(“GOOS”)
+		var goos string = os.Getenv(“OS”)
 		fmt.Printf(“The operating system is: %s\n”, goos)
 		path := os.Getenv(“PATH”)
 		fmt.Printf(“Path is %s\n”, path)


### PR DESCRIPTION
os.Getenv(“GOOS”)在win7下获取不到，os.Getenv(“OS”)可以获取
