### PR TITLE
[Typo] Fix wrong double quotation marks

### DIFF
--- a/eBook/04.4.md
+++ b/eBook/04.4.md
@@ -80,7 +80,7 @@ var str string = "Go says hello to the world!"
 ```go
 var a = 15
 var b = false
-var str = “Go says hello to the world!”
+var str = "Go says hello to the world!"
 ```
 
 或：


### PR DESCRIPTION
Fix a typo, we must use english style double quotation marks when declaring variable.

By @dbarobin