### PR TITLE
Update 02.8.md

### DIFF
--- a/eBook/02.8.md
+++ b/eBook/02.8.md
@@ -1,6 +1,6 @@
 # 2.8 Go 解释器
 
-因为 Go 具有像动态语言那样快速编译的能力，自然而然地就有人会问 Go 语言能否在 REPL（read-eval-print loop）编程环境下实现。Sebastien Binet 已经使用这种环境实现了一个 Go 解释器，你可以在这个页面找到：[https://bitbucket.org/binet/igo](https://bitbucket.org/binet/igo)。
+因为 Go 具有像动态语言那样快速编译的能力，自然而然地就有人会问 Go 语言能否在 REPL（read-eval-print loop）编程环境下实现。Sebastien Binet 已经使用这种环境实现了一个 Go 解释器，你可以在这个页面找到：[https://github.com/sbinet/igo](https://github.com/sbinet/igo)。
 
 ## 链接
 


### PR DESCRIPTION
文中引用的go解释器原项目已废弃，新项目托管在github上