### PR TITLE
修复10.8的代码，使之能够运行在Go1.5.1下

### DIFF
--- a/eBook/10.8.md
+++ b/eBook/10.8.md
@@ -7,7 +7,11 @@ Go 开发者不需要写代码来释放程序中不再使用的变量和结构�
 如果想知道当前的内存状态，可以使用：
 
 ```go
-fmt.Printf("%d\n", runtime.MemStats.Alloc/1024)
+// fmt.Printf("%d\n", runtime.MemStats.Alloc/1024)
+// 此处代码在 Go 1.5.1下不再有效，更正为
+var m runtime.MemStats
+runtime.ReadMemStats(&m)
+fmt.Printf("%d Kb\n", m.Alloc / 1024)
 ```
 
 上面的程序会给出已分配内存的总量，单位是 Kb。进一步的测量参考 [文档页面](http://golang.org/pkg/runtime/#MemStatsType)。


### PR DESCRIPTION
抱歉Linux下用vim编辑fileformat=dos的文件总不在文件尾添加newline at the end of File，请无视最后一行的diff