### PR TITLE
修正 13.1 原文实现方法的错误和翻译拼写错误

### DIFF
--- a/eBook/13.1.md
+++ b/eBook/13.1.md
@@ -58,7 +58,7 @@ if f, err := Sqrt(-1); err != nil {
 }
 ```
 
-由于 `fmt.Printf` 会自动调用 `String()` 方法 （参见 [10.7 节](10.7.md)），所以错误信息 “Error: math - square root of negative number” 会打印出来。通常（错误信息）都会有像 “Error:” 这样的前缀，所以你的错误信息不要以大写字母开头。
+由于 `fmt.Printf` 会自动调用 `String()` 方法(译者注: 此处的调用方法应该为 `Error()`) （参见 [10.7 节](10.7.md)），所以错误信息 “Error: math - square root of negative number” 会打印出来。通常（错误信息）都会有像 “Error:” 这样的前缀，所以你的错误信息不要以大写字母开头。
 
 在大部分情况下自定义错误结构类型很有意义的，可以包含除了（低层级的）错误信息以外的其它有用信息，例如，正在进行的操作（打开文件等），全路径或名字。看下面例子中 os.Open 操作触发的 PathError 错误：
 
@@ -70,6 +70,7 @@ type PathError struct {
 	Err error  // Returned by the system call.
 }
 
+// 译者注：此处实现的方法应该为 Error()
 func (e *PathError) String() string {
 	return e.Op + “ ” + e.Path + “: “+ e.Err.Error()
 }
@@ -107,6 +108,7 @@ type SyntaxError struct {
 	Offset int64
 }
 
+// 译者注: 此处实现的方法应该为 Error()
 func (e *SyntaxError) String() string { return e.msg }
 ```
 
@@ -119,7 +121,7 @@ if serr, ok := err.(*json.SyntaxError); ok {
 }
 ```
 
-包也可以用额外的方法（methods）定义特定的错误，比如 net.Errot：
+包也可以用额外的方法（methods）定义特定的错误，比如 net.Error：
 
 ```go
 package net


### PR DESCRIPTION
见 “13.1 错误处理” 章节部分问题 #211