### PR TITLE
FIX 10.6.9

### DIFF
--- a/eBook/10.6.md
+++ b/eBook/10.6.md
@@ -648,7 +648,7 @@ Go 不需要一个显式的类定义，如同 Java、C++、C# 等那样，相反
 ```go
 type Integer int
 func (i *Integer) String() string {
-    return strconv.Itoa(i)
+    return strconv.Itoa(int(*i))
 }
 ```
 


### PR DESCRIPTION
cannot use i (type *Integer) as type int in argument to strconv.Itoa