### PR TITLE
Update 09.1.md

### DIFF
--- a/eBook/09.1.md
+++ b/eBook/09.1.md
@@ -54,6 +54,7 @@ func main() {
 	- `math/big`: 大数的实现和计算。  　　
 - `container`-`/list-ring-heap`: 实现对集合的操作。  
 	- `list`: 双链表。
+	- `ring`: 环形链表。
 
 下面代码演示了如何遍历一个链表(当 l 是 `*List`)：
 
@@ -62,8 +63,6 @@ for e := l.Front(); e != nil; e = e.Next() {
 	//do something with e.Value
 }
 ```
-
-	- `ring`: 环形链表。
 
 - `time`-`log`:  
 	- `time`: 日期和时间的基本操作。  


### PR DESCRIPTION
“环形链表”那一行往前挪了，放在示例代码之后，否则无法显示成对应的格式。