### PR TITLE
修改defer关闭文件代码片段中的错误

### DIFF
--- a/eBook/12.7.md
+++ b/eBook/12.7.md
@@ -4,10 +4,10 @@
 
 ```go
 func data(name string) string {
-	f := os.Open(name, os.O_RDONLY, 0)
+	f, _ := os.OpenFile(name, os.O_RDONLY, 0)
 	defer f.Close() // idiomatic Go code!
-	contents := io.ReadAll(f)
-	return contents
+	contents, _ := ioutil.ReadAll(f)
+	return string(contents)
 }
 ```
 


### PR DESCRIPTION
1. `os.Open` 只能接收一个参数，`os.OpenFile`才能接收三个参数
1. 相关文件打开和读取操作的第二个返回值是 error 类型，不接收会产生下列错误

    >multiple-value os.OpenFile() in single-value context
    >multiple-value ioutil.ReadAll() in single-value context

1. 不存在`io.ReadAll()`函数