### PR TITLE
Fix GOROOT 路径层级错误

### DIFF
--- a/eBook/02.3.md
+++ b/eBook/02.3.md
@@ -32,11 +32,11 @@
 
 3. 获取 Go 源代码
 
-	从 [官方页面](https://golang.org/dl/) 或 [国内镜像](http://www.golangtc.com/download) 下载 Go 的源码包到你的计算机上，然后将解压后的目录 `go` 通过命令移动到 `$GOROOT` 所指向的位置。
+	从 [官方页面](https://golang.org/dl/) 或 [国内镜像](http://www.golangtc.com/download) 下载 Go 的源码包到你的计算机上，然后将解压后的目录 `go` 通过命令移动到用户目录 。
 
 		wget https://storage.googleapis.com/golang/go<VERSION>.src.tar.gz
 		tar -zxvf go<VERSION>.src.tar.gz
-		sudo mv go $GOROOT
+		sudo mv go ~
 
 4. 构建 Go
 


### PR DESCRIPTION
文中GOROOT为~/go
如果使用mv命令移动，那么结果是 ~/go/go。这时cd $GOROOT/src 显然是错误的
所以需要将go目录直接移动到~/ 中既得  ~/go