### PR TITLE
fix the wrong comment

### DIFF
--- a/eBook/14.2.md
+++ b/eBook/14.2.md
@@ -525,8 +525,8 @@ for {
 通道类型可以用注解来表示它只发送或者只接收：
 
 ```go
-var send_only chan<- int 		// channel can only send data
-var recv_only <-chan int		// channel can only receive data
+var send_only chan<- int 		// channel can only receive data
+var recv_only <-chan int		// channel can only send data
 ```
 
 只接收的通道（<-chan T）无法关闭，因为关闭通道是发送者用来表示不再给通道发送值了，所以对只接收通道是没有意义的。通道创建的时候都是双向的，但也可以分配有方向的通道变量，就像以下代码：


### PR DESCRIPTION
the original words are :
A channel type may be annotated to specify that it may only send or only receive in certain code:
```go
var send_only chan<- int // channel can only receive data
var recv_only <-chan int // channel can only send data
```