### PR TITLE
Update 11.3.md

### DIFF
--- a/eBook/11.3.md
+++ b/eBook/11.3.md
@@ -83,7 +83,7 @@ func (ci *Circle) Area() float32 {
     The type of areaIntf is: *main.Square
     areaIntf does not contain a variable of type Circle
 
-程序行中定义了一个新类型 `Circle`，它也实现了 `Shaper` 接口。 `t, ok := areaIntf.(*Square); ok ` 测试 `areaIntf` 里是否一个包含 'Square' 类型的变量，结果是确定的；然后我们测试它是否包含一个 'Circle' 类型的变量，结果是否定的。
+程序中定义了一个新类型 `Circle`，它也实现了 `Shaper` 接口。 `if t, ok := areaIntf.(*Square); ok ` 测试 `areaIntf` 里是否有一个包含 `*Square` 类型的变量，结果是确定的；然后我们测试它是否包含一个 `*Circle` 类型的变量，结果是否定的。
 
 **备注**
 


### PR DESCRIPTION
修改一些bug
sq1 := new(Square)时， sq1是Square指针类型， 而下面方法实现也是指针类型， 所有应该写*Square