### PR TITLE
Update 12.3.md

### DIFF
--- a/eBook/12.3.md
+++ b/eBook/12.3.md
@@ -26,7 +26,7 @@ func CopyFile(dstName, srcName string) (written int64, err error) {
 	}
 	defer src.Close()
 
-	dst, err := os.OpenFile(dstName, os.O_WRONLY|os.O_CREATE, 0644)
+	dst, err := os.Create(dstName)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Fixed a that if dstName file's length is longer than srcName file, io.Copy will cover only part content of srcName file.
If file srcName 's content is "abc", dstName's content is "1234" ,the result of io.Copy(dst, src) is "abc4" not "abc"