### PR TITLE
fix case of shorter length of inputString

### DIFF
--- a/eBook/exercises/chapter_12/remove_3till5char.go
+++ b/eBook/exercises/chapter_12/remove_3till5char.go
@@ -15,6 +15,7 @@ func main() {
 	defer outputFile.Close()
 	inputReader := bufio.NewReader(inputFile)
 	outputWriter := bufio.NewWriter(outputFile)
+	var outputString string
 	for {
 		// inputString, readerError := inputReader.ReadString('\n')
 		inputString, _, readerError := inputReader.ReadLine()
@@ -23,7 +24,13 @@ func main() {
 			break
 		}
 		//fmt.Printf("The input was: --%s--", inputString)
-		outputString := string([]byte(inputString)[2:5]) + "\r\n"
+		if len(inputString) < 3 {
+			outputString = "\r\n"
+		} else if len(inputString) < 5 {
+			outputString = string([]byte(inputString)[2:len(inputString)]) + "\r\n"
+		} else {
+        		outputString = string([]byte(inputString)[2:5]) + "\r\n"
+		}
 		//fmt.Printf("The output was: --%s--", outputString)
 		_, err := outputWriter.WriteString(outputString)
 		//fmt.Printf("Number of bytes written %d\n", n)


### PR DESCRIPTION
当读取的inputString的长度小于5时，string([]byte(inputString)[2:5])会出现bug