### PR TITLE
Update min_interface.go

### DIFF
--- a/eBook/exercises/chapter_11/min_interface.go
+++ b/eBook/exercises/chapter_11/min_interface.go
@@ -5,6 +5,7 @@ type Miner interface {
 	Len() int
 	ElemIx(ix int) interface{}
 	Less(i, j int) bool
+	Swap(i, j int)
 }
 
 func Min(data Miner) interface{} {
@@ -12,6 +13,8 @@ func Min(data Miner) interface{} {
 	for i := 1; i < data.Len(); i++ {
 		if data.Less(i, i-1) {
 			min = data.ElemIx(i)
+		} else {
+			data.Swap(i, i-1)
 		}
 	}
 	return min
@@ -22,9 +25,11 @@ type IntArray []int
 func (p IntArray) Len() int                  { return len(p) }
 func (p IntArray) ElemIx(ix int) interface{} { return p[ix] }
 func (p IntArray) Less(i, j int) bool        { return p[i] < p[j] }
+func (p IntArray) Swap(i, j int)             { p[i], p[j] = p[j], p[i] }
 
 type StringArray []string
 
 func (p StringArray) Len() int                  { return len(p) }
 func (p StringArray) ElemIx(ix int) interface{} { return p[ix] }
 func (p StringArray) Less(i, j int) bool        { return p[i] < p[j] }
+func (p StringArray) Swap(i, j int)             { p[i], p[j] = p[j], p[i] }


### PR DESCRIPTION
Min(data Miner) 方法存在bug，原因是： 该方法的逻辑类似冒泡排序, 将Miner类型变量的集合挨个两两比对，但方法中仅将两变量的较小值取出（Less()方法），并赋值记录为min，最后返回，并没有进行“冒泡”这个swap操作。
因此补充了Swap()相关的接口和实现定义，并补充了Swap()在Min()方法中的逻辑。