### PR TITLE
fix: example code of startProcess

### DIFF
--- a/eBook/13.6.md
+++ b/eBook/13.6.md
@@ -52,7 +52,7 @@ The process id is &{2054 0}total 2056
 
 ```go
 // 2nd example: show all processes
-pid, err = os.StartProcess("/bin/ps", []string{"-e", "-opid,ppid,comm"}, procAttr)  
+pid, err = os.StartProcess("/bin/ps", []string{"ps", "-e", "-opid,ppid,comm"}, procAttr)  
 
 if err != nil {
 		fmt.Printf("Error %v starting process!", err)  //


### PR DESCRIPTION
the first element of `argv` should be the command self which is 'ps' in this case, as the official doc says: "The argv slice will become os.Args in the new process, so it normally starts with the program name."