### PR TITLE
翻译修改

### DIFF
--- a/eBook/08.6.md
+++ b/eBook/08.6.md
@@ -34,7 +34,7 @@ func main() {
 	inverted:
 	Key: 34, Value: golf / Key: 23, Value: charlie / Key: 16, Value: hotel / Key: 87, Value: delta / Key: 98, Value: lima / Key: 12, Value: foxtrot / Key: 43, Value: kili / Key: 56, Value: bravo / Key: 65, Value: juliet /
 
-如果原始 value 值不唯一那么这么做肯定会出错；为了保证不出错，当遇到不唯一的 key 时应当立刻停止，这样可能会导致没有包含原 map 的所有键值对！一种解决方法就是仔细检查唯一性并且使用多值 map，比如使用 `map[int][]string` 类型。
+如果原始 value 值不唯一那这么做肯定会出问题；这种情况下不会报错，但是当遇到不唯一的 key 时应当直接停止对调，且此时对调后的 map 很可能没有包含原 map 的所有键值对！一种解决方法就是仔细检查唯一性并且使用多值 map，比如使用 `map[int][]string` 类型。
 
 **练习 8.2**
 


### PR DESCRIPTION
原文:This goes wrong of course when the original value items are not unique; in that case no error occurs, but the processing of the inverted map is simply stopped when a nonunique key is encountered, and it will most probably not contain all pairs from the original map!
我觉得这一句应该是因为编译器这种情况下不会报错才特地提醒的
虽然原文的这个句式有点让人费解...