### PR TITLE
练习序号有误

### DIFF
--- a/eBook/12.5.md
+++ b/eBook/12.5.md
@@ -46,7 +46,7 @@ func main() {
 
 在 12.6 章节，我们将看到如何使用缓冲写入。
 
-**练习 12.5**：[cat_numbered.go](exercises/chapter_12/cat_numbered.go)
+**练习 12.6**：[cat_numbered.go](exercises/chapter_12/cat_numbered.go)
 
 扩展 cat.go 例子，使用 flag 添加一个选项，目的是为每一行头部加入一个行号。使用 `cat -n test` 测试输出。
 


### PR DESCRIPTION
Exercise 12. 6:cat_numbered.go
Extend the example from listing 12.8 to process a flag which indicates that every line read should be preceded by a line number in the output. Test it out with:  cat –n test