### PR TITLE
修正 net.ListenTCP(string, *TCPAddr) 的参数

### DIFF
--- a/eBook/15.1.md
+++ b/eBook/15.1.md
@@ -239,7 +239,7 @@ func main() {
 func initServer(hostAndPort string) *net.TCPListener {
 	serverAddr, err := net.ResolveTCPAddr("tcp", hostAndPort)
 	checkError(err, "Resolving address:port failed: '"+hostAndPort+"'")
-	listener, err := net.ListenTCP("tcp", serverAddr.String())
+	listener, err := net.ListenTCP("tcp", serverAddr)
 	checkError(err, "ListenTCP: ")
 	println("Listening to: ", listener.Addr().String())
 	return listener


### PR DESCRIPTION
net.ListenTCP(string, *TCPAddr) 的参数为(string, *TCPAddr)