### PR TITLE
修复打印的斐波那契数列出现0的问题

### DIFF
--- a/eBook/exercises/chapter_14/gofibonacci3.go
+++ b/eBook/exercises/chapter_14/gofibonacci3.go
@@ -30,6 +30,7 @@ func fib() <-chan int {
 			x <- <-a + <-b
 		}
 	}()
+	<- out
 	return out
 }
 


### PR DESCRIPTION
因为 chan c 中并没有把最开始放入的0给移除，造成打印数列中多出一个错误的0值。