### PR TITLE
修正12.3章中的提示

### DIFF
--- a/eBook/12.3.md
+++ b/eBook/12.3.md
@@ -36,7 +36,7 @@ func CopyFile(dstName, srcName string) (written int64, err error) {
 }
 ```
 
-注意 `defer` 的使用：当打开目标文件成功，那么 `defer` 能够确保 `src.Close()` 执行。如果不这么做，文件会一直保持打开状态并占用资源。
+注意 `defer` 的使用：当打开dst文件时发生了错误，那么 `defer` 仍然能够确保 `src.Close()` 执行。如果不这么做，src文件会一直保持打开状态并占用资源。
 
 ## 链接
 

--- a/eBook/12.3.md
+++ b/eBook/12.3.md
@@ -36,7 +36,7 @@ func CopyFile(dstName, srcName string) (written int64, err error) {
 }
 ```
 
-注意 `defer` 的使用：当打开目标文件时发生了错误，那么 `defer` 仍然能够确保 `src.Close()` 执行。如果不这么做，文件会一直保持打开状态并占用资源。
+注意 `defer` 的使用：当打开目标文件成功，那么 `defer` 能够确保 `src.Close()` 执行。如果不这么做，文件会一直保持打开状态并占用资源。
 
 ## 链接
 


### PR DESCRIPTION
示例代码中，如果打开目标文件发生错误，就return，并不会调度其后的defer代码，所以这种情况下是不会保证关闭文件的。
其实如果打开目标文件发生错误，那么返回的文件句柄是空，没有关闭的必要。