### PR TITLE
Update defer.go

### DIFF
--- a/eBook/examples/chapter_6/defer.go
+++ b/eBook/examples/chapter_6/defer.go
@@ -13,5 +13,5 @@ func Function1() {
 }
 
 func Function2() {
-	fmt.Printf("Function2: Deferred until the end of the calling function!")
+	fmt.Printf("Function2: Deferred until the end of the calling function!\n")
 }


### PR DESCRIPTION
fmt.Printf("Function2: Deferred until the end of the calling function!")添加换行
fmt.Printf("Function2: Deferred until the end of the calling function!\n")
如果defer去掉的话输出会是：
In function1 at the top
Function2: Deferred until the end of the calling function!In function1 at the bottom!
没有换行，不美观