### PR TITLE
Minor fix to the return type of syscall.Open()

### DIFF
--- a/eBook/13.1.md
+++ b/eBook/13.1.md
@@ -133,13 +133,13 @@ type Error interface {
 
 正如你所看到的一样，所有的例子都遵循同一种命名规范：错误类型以 “Error” 结尾，错误变量以 “err” 或 “Err” 开头。
 
-syscall 是低阶外部包，用来提供系统基本调用的原始接口。它们返回整数的错误码；类型 syscall.Errno 实现了 Error 接口。
+syscall 是低阶外部包，用来提供系统基本调用的原始接口。它们返回封装整数类型错误码的syscall.Errno；类型 syscall.Errno 实现了 Error 接口。
 
 大部分 syscall 函数都返回一个结果和可能的错误，比如：
 
 ```go
 r, err := syscall.Open(name, mode, perm)
-if err != 0 {
+if err != nil {
 	fmt.Println(err.Error())
 }
 ```


### PR DESCRIPTION
syscall.Open() returns a syscall.Errno, not an int. Minor fix to the
sample code and description.

Signed-off-by: Talons Lee <talons.lee@gmail.com>