### PR TITLE
Fix typos 'strcut' in 10.1.md

### DIFF
--- a/eBook/10.1.md
+++ b/eBook/10.1.md
@@ -136,7 +136,7 @@ type Point struct { x, y int }
 
 ![](images/10.1_fig10.1-2.jpg?raw=true)
 
-类型 strcut1 在定义它的包 pack1 中必须是唯一的，它的完全类型名是：`pack1.struct1`。
+类型 struct1 在定义它的包 pack1 中必须是唯一的，它的完全类型名是：`pack1.struct1`。
 
 下面的例子 [Listing 10.2—person.go](examples/chapter_10/person.go) 显示了一个结构体 Person，一个方法，方法有一个类型为 `*Person` 的参数（因此对象本身是可以被改变的），以及三种调用这个方法的不同方式：
 
@@ -239,7 +239,7 @@ type Node struct {
 二叉树中每个节点最多能链接至两个节点：左节点（le）和右节点（ri），这两个节点本身又可以有左右节点，依次类推。树的顶层节点叫根节点（**root**），底层没有子节点的节点叫叶子节点（**leaves**），叶子节点的 `le` 和 `ri` 指针为 nil 值。在 Go 中可以如下定义二叉树：
 
 ```go
-type Tree strcut {
+type Tree struct {
     le      *Tree
     data    float64
     ri      *Tree


### PR DESCRIPTION
Thanks for the translation. I found those typos in `10.1.md`.