### PR TITLE
resouces 拼错了

### DIFF
--- a/eBook/14.2.md
+++ b/eBook/14.2.md
@@ -367,7 +367,7 @@ func (s semaphore) P(n int) {
 	}
 }
 
-// release n resouces
+// release n resources
 func (s semaphore) V(n int) {
 	for i:= 0; i < n; i++{
 		<- s


### PR DESCRIPTION
world “resouces” -> "resources"