### PR TITLE
添加有效的测试一个值是否实现了某个接口的方法

### DIFF
--- a/eBook/11.5.md
+++ b/eBook/11.5.md
@@ -12,6 +12,18 @@ if sv, ok := v.(Stringer); ok {
 }
 ```
 
+译者注:
+直接通过变量判断实现某个接口的时候，左值需要为interface{}类型，否则会出现类似异常：
+```go
+/invalid operation: s1 (variable of type *St1) is not an interface
+```
+所以,正确的修改方式为
+```go
+var vv interface{} = v
+if _,ok := vv.(Stringer); ok {
+}
+```
+
 `Print` 函数就是如此检测类型是否可以打印自身的。
 
 接口是一种契约，实现类型必须满足它，它描述了类型的行为，规定类型可以做什么。接口彻底将类型能做什么，以及如何做分离开来，使得相同接口的变量在不同的时刻表现出不同的行为，这就是多态的本质。


### PR DESCRIPTION
判断变量是否实现接口函数的时候，左值需要interface{}类型，否则会出现异常
```go
invalid operation: s1 (variable of type *St1) is not an interface
```
所以,正确的修改方式为
```go
var vv interface{} = v
if _,ok := vv.(Stringer); ok {
}
```