### PR TITLE
修正 05.3.md 中示例的语法错误

### DIFF
--- a/eBook/05.3.md
+++ b/eBook/05.3.md
@@ -144,7 +144,7 @@ switch initialization {
 这种形式可以非常优雅地进行条件判断：
 
 ```go
-switch result := calculate() {
+switch result := calculate(); {
 	case result < 0:
 		...
 	case result > 0:
@@ -157,7 +157,7 @@ switch result := calculate() {
 在下面这个代码片段中，变量 a 和 b 被平行初始化，然后作为判断条件：
 
 ```go
-switch a, b := x[i], y[j] {
+switch a, b := x[i], y[j]; {
 	case a < b: t = -1
 	case a == b: t = 0
 	case a > b: t = 1


### PR DESCRIPTION
switch包含初始化语句进行条件判断时，初始化语句后应加上分号，否则会报语法错误
```
syntax error: cannot use result := calculate() as value
```

执行环境：go version go1.15.5 linux/amd64