### PR TITLE
Update 10.6.md

### DIFF
--- a/eBook/10.6.md
+++ b/eBook/10.6.md
@@ -526,8 +526,8 @@ func (c *Customer) String() string {
 输出：
 
     Barak Obama
-    Log:{1 - Yes we can!
-    2 - After me the world will be a better place!}
+    Log:1 - Yes we can!
+    2 - After me the world will be a better place!
 
 内嵌的类型不需要指针，`Customer` 也不需要 `Add` 方法，它使用 `Log` 的 `Add` 方法，`Customer` 有自己的 `String` 方法，并且在它里面调用了 `Log` 的 `String` 方法。
 

--- a/eBook/10.6.md
+++ b/eBook/10.6.md
@@ -519,7 +519,7 @@ func (l *Log) String() string {
 }
 
 func (c *Customer) String() string {
-	return c.Name + "\nLog:" + fmt.Sprintln(c.Log)
+	return c.Name + "\nLog:" + fmt.Sprintln(c.Log.String())
 }
 ```
 


### PR DESCRIPTION
如下文:
Customer 有自己的 String 方法，并且在它里面调用了 Log 的 String 方法。

这里有一个疑问就是为什么没有自动diaoyong `Log.String()` 如下一章讲的，在fmt中会自动调用 `String()` 方法。

```
package main

import (
	"fmt"
)

type Log struct {
	msg string
	test string
}

type Customer struct {
	Name string
	Log
}

func main() {
	c := &Customer{"Barak Obama", Log{"1 - Yes we can!", "test"}}
	c.Add("2 - After me the world will be a better place!")
	fmt.Println(c)

}

func (l *Log) Add(s string) {
	l.msg += "\n" + s
}

func (l *Log) String() string {
	return l.msg
}

func (c *Customer) String() string {
	return c.Name + "\nLog:" + fmt.Sprintln(c.Log)
}
```

```
Barak Obama
Log:{1 - Yes we can!
2 - After me the world will be a better place! test}
```
test 被输出了