### PR TITLE
Update 06.2.md

### DIFF
--- a/eBook/06.2.md
+++ b/eBook/06.2.md
@@ -124,11 +124,12 @@ func getX2AndX3_2(input int) (x2 int, x3 int) {
     num = 10, 2x num = 20, 3x num = 30    
     num = 10, 2x num = 20, 3x num = 30 
 
-警告：
+提示：
 
-- return 或 return var 都是可以的。
-- 不过 `return var = expression`（表达式） 会引发一个编译错误：`syntax error: unexpected =, expecting semicolon or newline or }`。
-        
+虽然 `return` 或 `return var` 都是可以的，但是 `return var = expression`（表达式） 会引发一个编译错误：
+
+`syntax error: unexpected =, expecting semicolon or newline or }`。
+
 即使函数使用了命名返回值，你依旧可以无视它而返回明确的值。        
             
 任何一个非命名返回值（使用非命名返回值是很糟的编程习惯）在 `return` 语句里面都要明确指出包含返回值的变量或是一个可计算的值（就像上面警告所指出的那样）。


### PR DESCRIPTION
原文在这里：
Caution: return or return var is ok, but return var = expression gives a compiler error: syntax error: unexpected =, expecting semicolon or newline or }