### PR TITLE
fix spelling error in 11.1.md

### DIFF
--- a/eBook/11.1.md
+++ b/eBook/11.1.md
@@ -18,7 +18,7 @@ type Namer interface {
 
 上面的 `Namer` 是一个 **接口类型**。
 
-（按照约定，只包含一个方法的）接口的名字由方法名加 `[e]r` 后缀组成，例如 `Printer`、`Reader`、`Writer`、`Logger`、`Converter` 等等。还有一些不常用的方式（当后缀 `er` 不合适时），比如 `Recoverable`，此时接口名以 `able` 结尾，或者以 `I` 开头（像 `.NET` 或 `Java` 中那样）。
+（按照约定，只包含一个方法的）接口的名字由方法名加 `er` 后缀组成，例如 `Printer`、`Reader`、`Writer`、`Logger`、`Converter` 等等。还有一些不常用的方式（当后缀 `er` 不合适时），比如 `Recoverable`，此时接口名以 `able` 结尾，或者以 `I` 开头（像 `.NET` 或 `Java` 中那样）。
 
 Go 语言中的接口都很简短，通常它们会包含 0 个、最多 3 个方法。
 


### PR DESCRIPTION
原11.1.md中21行的对interface的规定命名中的： er 误输入为 [e]r