### PR TITLE
修正14.3中关于检测通道阻塞的错误

### DIFF
--- a/eBook/14.3.md
+++ b/eBook/14.3.md
@@ -27,7 +27,7 @@ if v, ok := <-ch; ok {
 }
 ```
 
-或者在 for 循环中接收的时候，当关闭或者阻塞的时候使用 break：
+或者在 for 循环中接收的时候，当关闭的时候使用 break：
 
 ```go
 v, ok := <-ch
@@ -35,6 +35,21 @@ if !ok {
   break
 }
 process(v)
+```
+
+而检测通道当前是否阻塞，需要使用 select（参见第 [14.4](14.4.md) 节）。
+
+```go
+select {
+case v, ok := <-ch:
+  if ok {
+    process(v)
+  } else {
+    fmt.Println("The channel is closed")
+  }
+default:
+  fmt.Println("The channel is blocked")
+}
 ```
 
 在示例程序 14.2 中使用这些可以改进为版本 goroutine3.go，输出相同。


### PR DESCRIPTION
原版本中 “当关闭或者阻塞的时候使用 break” 说法有误，如果通道正在阻塞，则协程运行到v, ok := <-ch就会暂停，不会进入if语句。