### PR TITLE
fixed chapter_19 examples error :add http header

### DIFF
--- a/eBook/examples/chapter_19/goto_v2/main.go
+++ b/eBook/examples/chapter_19/goto_v2/main.go
@@ -26,6 +26,7 @@ func Redirect(w http.ResponseWriter, r *http.Request) {
 func Add(w http.ResponseWriter, r *http.Request) {
 	url := r.FormValue("url")
 	if url == "" {
+		w.Header().Set("Content-Type", "text/html")
 		fmt.Fprint(w, AddForm)
 		return
 	}


### PR DESCRIPTION
您好：
书中19章的goto_v2示例代码，缺少http代码，可能会引起代码功能的问题。
经过本地测试，修改之后代码可用。后面章节应该也存在同样的问题。

    func Add(w http.ResponseWriter, r *http.Request) {
	    url := r.FormValue("url")
	    if url == "" {
		    w.Header().Set("Content-Type", "text/html")  //增加代码
		    fmt.Fprint(w, AddForm)
		    return
	    }
	    key := store.Put(url)
	    fmt.Fprintf(w, "http://localhost:8080/%s", key)
    }




