### PR TITLE
方法签名中少了数据类型

### DIFF
--- a/eBook/04.7.md
+++ b/eBook/04.7.md
@@ -108,7 +108,7 @@ func main() {
 `Replace` 用于将字符串 `str` 中的前 `n` 个字符串 `old` 替换为字符串 `new`，并返回一个新的字符串，如果 `n = -1` 则替换所有字符串 `old` 为字符串 `new`：
 
 ```go
-strings.Replace(str, old, new, n) string
+strings.Replace(str, old, new string, n int) string
 ```
 
 ## 4.7.5 统计字符串出现次数


### PR DESCRIPTION
111行中的strings.Replace(str, old, new, int) string 中没有数据类型，但是119行中的strings.Count(s, str string) int中却有数据类型。
个人认为没必要偷这种懒，行文风格一致有助于读者理解。