### PR TITLE
fix Go Tour chinese version URL

### DIFF
--- a/eBook/01.1.md
+++ b/eBook/01.1.md
@@ -50,7 +50,7 @@ Go 编程语言的维基百科：[en.wikipedia.org/wiki/Go_(programming_language
 
 Go 语言相关资源的搜索引擎页面：[gowalker.org](https://gowalker.org)
 
-Go 语言还有一个运行在 Google App Engine 上的 [Go Tour](http://tour.golang.org/)，你也可以通过执行命令 `go install go-tour.googlecode.com/hg/gotour` 安装到你的本地机器上。对于中文读者，可以访问该指南的 [中文版本](http://go-tour-zh.appspot.com/)，或通过命令 `go install https://bitbucket.org/mikespook/go-tour-zh/gotour` 进行安装。
+Go 语言还有一个运行在 Google App Engine 上的 [Go Tour](http://tour.golang.org/)，你也可以通过执行命令 `go install go-tour.googlecode.com/hg/gotour` 安装到你的本地机器上。对于中文读者，可以访问该指南的 [中文版本](https://tour.go-zh.org/welcome/1)，或通过命令 `go install https://bitbucket.org/mikespook/go-tour-zh/gotour` 进行安装。
 
 ## 链接
 


### PR DESCRIPTION
original link address 【[old 中文版本](http://go-tour-zh.appspot.com/)】 cannot be opened, this may be the new link address 【[new 中文版本](https://tour.go-zh.org/welcome/1)】