### PR TITLE
fix links not found

### DIFF
--- a/eBook/07.1.md
+++ b/eBook/07.1.md
@@ -138,15 +138,15 @@ func main() {
 
 **练习**
 
-练习7.1：[array_value.go](examples/chapter_7/array_value.go):
+练习7.1：[array_value.go](exercises/chapter_7/array_value.go):
 
 证明当数组赋值时，发生了数组内存拷贝。
 
-练习7.2：[for_array.go](examples/chapter_7/for_array.go): 
+练习7.2：[for_array.go](exercises/chapter_7/for_array.go): 
 
 写一个循环并用下标给数组赋值（从 0 到 15）并且将数组打印在屏幕上。
 
-练习7.3：[fibonacci_array.go](examples/chapter_7/fibonacci_array.go): 
+练习7.3：[fibonacci_array.go](exercises/chapter_7/fibonacci_array.go): 
 
 在[第 6.6 节](06.6.md) 我们看到了一个递归计算 Fibonacci 数值的方法。但是通过数组我们可以更快的计算出 Fibonacci 数。完成该方法并打印出前 50 个 Fibonacci 数字。
 


### PR DESCRIPTION
The link of `array_value.go`, `for_array.go` and `fibonacci_array.go` is nonexistent, the 'examples' in these links should be 'exercises'.