### PR TITLE
Newstruct1作为一个函数，应使用()调用。使用{}会报编译错误。

### DIFF
--- a/eBook/18.4.md
+++ b/eBook/18.4.md
@@ -22,7 +22,7 @@ ms := &struct1{10, 15.5, "Chris"}
 
 
 ```go    
-ms := Newstruct1{10, 15.5, "Chris"}
+ms := Newstruct1(10, 15.5, "Chris")
 func Newstruct1(n int, f float32, name string) *struct1 {
     return &struct1{n, f, name} 
 }


### PR DESCRIPTION
修复了18.4节最后一个例程的bug